### PR TITLE
Fix packaging

### DIFF
--- a/eping.el
+++ b/eping.el
@@ -44,9 +44,8 @@
 
 ;;; Code:
 
-(declare-function -snoc "dash")
-(declare-function -cons* "dash")
-(declare-function s-chomp "s")
+(require 'dash)
+(require 's)
 
 (defvar eping-domain-options
   '("wikipedia.org" "startpage.com" "gnu.org")
@@ -56,6 +55,7 @@
   "List of how many times to ping the domain.
 Eping will present this as list to select from for users.")
 
+;;;###autoload
 (defun eping (domain number-pings)
   "Check internet connectivity with ping.
 


### PR DESCRIPTION
- load dash, s
- add autoload cookie(reference https://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html)

`dash` and `s` functions are not autoloaded so it must be loaded. For example if `M-x eping` is evaluated before loading `dash` and `s` then the following error occurs.

```
call-interactively: Symbol’s function definition is void: -cons*
``` 

