### PR TITLE
Support windows ping.exe

### DIFF
--- a/eping.el
+++ b/eping.el
@@ -56,7 +56,10 @@ With prefix arg SPEAK, the output is spoken by espeak."
          (completing-read "Number of pings: " eping-number-pings-options nil t)
          current-prefix-arg))
 
-  (let ((command (list "ping" "-c" number-pings domain)))
+  (let ((command (list "ping" (if (eq system-type 'windows-nt)
+				  "-n"
+				"-c")
+		       number-pings domain)))
     (make-process :name "eping"
                   :command command
                   :sentinel (if speak


### PR DESCRIPTION
Windows use a different flag ("-n") for count:

```
PS C:\Users\pidsleywin> ping -n 1 wikipedia.org

Ping wird ausgeführt für wikipedia.org [91.198.174.192] mit 32 Bytes Daten:
Antwort von 91.198.174.192: Bytes=32 Zeit=12ms TTL=58

Ping-Statistik für 91.198.174.192:
    Pakete: Gesendet = 1, Empfangen = 1, Verloren = 0
    (0% Verlust),
Ca. Zeitangaben in Millisek.:
    Minimum = 12ms, Maximum = 12ms, Mittelwert = 12ms
PS C:\Users\pidsleywin> ping -c 1 wikipedia.org
Zugriff verweigert. Für die Option "-c" sind Administratorberechtigungen erforderlich.
```